### PR TITLE
fix(resources/profiles): transfer endpoint url is now correct

### DIFF
--- a/resources/profiles/profiles.resource.ts
+++ b/resources/profiles/profiles.resource.ts
@@ -81,6 +81,6 @@ export class CoinbaseProfiles extends CoinbaseResource {
    * @returns {Promise<void>}
    */
   public async transfer(from: string, to: string, currency: string, amount: string): Promise<void> {
-    return await this.request.post({ from, to, currency, amount }, `/profiles/transfer`)
+    return await this.request.post({ from, to, currency, amount }, `/transfer`)
   }
 }


### PR DESCRIPTION
Had it as `/profiles/transfer` and it is now correctly `/transfer` as the prefix is handled by the resource itself...