### PR TITLE
refactor(core/auth): simpler and better test coverage

### DIFF
--- a/core/coinbase.auth.test.ts
+++ b/core/coinbase.auth.test.ts
@@ -1,0 +1,55 @@
+import { decodeBase64 } from '@std/encoding'
+import { CoinbaseAuth, type CoinbaseAuthKeys } from './coinbase.auth.ts'
+import { assertAlmostEquals, assertEquals, assertExists } from '@std/assert'
+import { AuthUtility } from '../utilities/auth.utility.ts'
+
+const auth_data = {
+  key: 'test_key',
+  secret: 'dGVzdF9zZWNyZXQ=',
+  passphrase: 'test_passphrase',
+}
+const auth = new CoinbaseAuth(auth_data)
+
+interface request {
+  path: string
+  method: string
+  body?: unknown
+}
+
+Deno.test('CoinbaseAuth.keys', async (test) => {
+  async function test_keys(keys: CoinbaseAuthKeys, request: request) {
+    assertEquals(keys.key, 'test_key')
+    assertEquals(keys.passphrase, 'test_passphrase')
+    assertAlmostEquals(parseFloat(keys.timestamp), Date.now() / 1000, 0.01)
+    const key = await AuthUtility.CreateSigningKey(auth_data.secret, 'verify')
+    const body = request.body === undefined ? '' : JSON.stringify(request.body)
+    const verified = await AuthUtility.Verify(
+      `${keys.timestamp}${request.method}${request.path}${body}`,
+      decodeBase64(keys.signature),
+      key,
+    )
+    assertEquals(verified, true)
+  }
+
+  await test.step('returns the correct keys with no body', async () => {
+    const data = { path: '/test', method: 'GET' }
+    const keys = await auth.keys(data.path, data.method)
+    await test_keys(keys, data)
+  })
+
+  await test.step('returns the correct keys with a body', async () => {
+    const data = { path: '/test/body', method: 'POST', body: { test: 'value' } }
+    const keys = await auth.keys(data.path, data.method, data.body)
+    await test_keys(keys, data)
+  })
+})
+
+Deno.test('CoinbaseAuth.headers', async (test) => {
+  await test.step('returns the correct headers', async () => {
+    const headers = await auth.headers('/testing', 'PUT')
+    assertEquals(headers['CB-ACCESS-KEY'], auth_data.key)
+    assertEquals(headers['CB-ACCESS-PASSPHRASE'], auth_data.passphrase)
+    assertExists(headers['CB-ACCESS-SIGN'])
+    assertAlmostEquals(parseFloat(headers['CB-ACCESS-TIMESTAMP']), Date.now() / 1000, 0.01)
+  })
+})

--- a/core/coinbase.auth.ts
+++ b/core/coinbase.auth.ts
@@ -1,0 +1,76 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { encodeBase64 as encode } from '@std/encoding'
+import type { CoinbaseAuthConfig } from '../core/coinbase.config.types.ts'
+import { AuthUtility } from '../utilities/auth.utility.ts'
+
+export interface CoinbaseAuthKeys {
+  key: string
+  passphrase: string
+  signature: string
+  timestamp: string
+}
+
+export interface CoinbaseAuthHeaders {
+  'CB-ACCESS-KEY': string
+  'CB-ACCESS-PASSPHRASE': string
+  'CB-ACCESS-SIGN': string
+  'CB-ACCESS-TIMESTAMP': string
+}
+
+/**
+ * Coinbase API authentication utility. Internal use only.
+ */
+export class CoinbaseAuth {
+  constructor(private readonly config: CoinbaseAuthConfig) {}
+
+  /**
+   * Returns Coinbase API authentication data, used in requests.
+   * @param {string} path Full path to the API endpoint.
+   * @param {string} method HTTP method.
+   * @param {unknown} body Any body, if applicable. Will be stringified.
+   * @returns {Promise<CoinbaseAuthKeys>} Authentication headers.
+   */
+  public async keys(
+    path: string,
+    method: string,
+    body: unknown | undefined = undefined,
+  ): Promise<CoinbaseAuthKeys> {
+    const timestamp = `${Date.now() / 1000}`
+    const message = `${timestamp}${method}${path}${body === undefined ? '' : JSON.stringify(body)}`
+    const key = await AuthUtility.CreateSigningKey(this.config.secret)
+    const signature = await AuthUtility.Sign(message, key)
+
+    return {
+      key: this.config.key,
+      passphrase: this.config.passphrase,
+      signature: encode(signature),
+      timestamp,
+    }
+  }
+
+  /**
+   * Returns Coinbase API authentication headers, used in requests.
+   * @param {string} path Full path to the API endpoint.
+   * @param {string} method HTTP method.
+   * @param {unknown} body Any body, if applicable. Will be stringified.
+   * @returns {Promise<CoinbaseAuthHeaders>} Authentication headers.
+   */
+  public async headers(
+    path: string,
+    method: string,
+    body: unknown | undefined = undefined,
+  ): Promise<CoinbaseAuthHeaders> {
+    const auth = await this.keys(path, method, body)
+    return {
+      'CB-ACCESS-KEY': auth.key,
+      'CB-ACCESS-PASSPHRASE': auth.passphrase,
+      'CB-ACCESS-SIGN': auth.signature,
+      'CB-ACCESS-TIMESTAMP': auth.timestamp,
+    }
+  }
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,8 @@
   "exports": "./mod.ts",
   "tasks": {
     "coverage": "deno test --coverage=coverage",
-    "coverage:lcov": "deno coverage --lcov --output=coverage/lcov.info"
+    "coverage:lcov": "deno coverage --lcov --output=coverage/lcov.info",
+    "coverage:html": "deno coverage coverage --html"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^0.226.0",

--- a/resources/request.ts
+++ b/resources/request.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { CoinbaseAuth } from '../utilities/auth.utility.ts'
+import { CoinbaseAuth } from '../core/coinbase.auth.ts'
 import { type Query, RequestUtility } from '../utilities/request.utility.ts'
 import type { CoinbaseConfig } from '../core/coinbase.config.ts'
 

--- a/utilities/auth.utility.test.ts
+++ b/utilities/auth.utility.test.ts
@@ -1,0 +1,36 @@
+import { AuthUtility } from './auth.utility.ts'
+import { assertEquals, assertInstanceOf } from '@std/assert'
+
+const secret = 'dGVzdF9zZWNyZXQ='
+
+Deno.test('AuthUtility.CreateSigningKey', async (test) => {
+  await test.step('should key that is an instance of CryptoKey', async () => {
+    const key = await AuthUtility.CreateSigningKey(secret)
+    assertInstanceOf(key, CryptoKey)
+  })
+
+  await test.step('should create a signing key from a secret', async () => {
+    const key = await AuthUtility.CreateSigningKey(secret)
+    assertEquals(key.usages, ['sign'])
+    assertEquals(key.algorithm.name, 'HMAC')
+    assertEquals(key.type, 'secret')
+  })
+
+  await test.step('should create a verification key from a secret', async () => {
+    const key = await AuthUtility.CreateSigningKey(secret, 'verify')
+    assertEquals(key.usages, ['verify'])
+    assertEquals(key.algorithm.name, 'HMAC')
+    assertEquals(key.type, 'secret')
+  })
+})
+
+Deno.test('AuthUtility.Sign/Verify', async (test) => {
+  await test.step('should sign a message with a key', async () => {
+    const message = 'test message'
+    const signing_key = await AuthUtility.CreateSigningKey(secret)
+    const signature = await AuthUtility.Sign(message, signing_key)
+
+    const verify_key = await AuthUtility.CreateSigningKey(secret, 'verify')
+    assertEquals(await AuthUtility.Verify(message, signature, verify_key), true)
+  })
+})


### PR DESCRIPTION
Precursor to changing how we handle auth accross the library. For now it has no outside changes at all.