### PR TITLE
feat(config): automatically use env vars for auth if available

### DIFF
--- a/core/coinbase.config.ts
+++ b/core/coinbase.config.ts
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { EnvironmentUtility } from '../utilities/environment.utility.ts'
 import type { CoinbaseAuthConfig, CoinbaseUrlConfig } from './coinbase.config.types.ts'
 
 /**
@@ -16,7 +17,14 @@ export class CoinbaseConfig {
   public readonly urls: CoinbaseUrlConfig
 
   constructor(auth?: CoinbaseAuthConfig, sandbox: boolean = false) {
-    this.auth = auth || { key: '', secret: '', passphrase: '' }
+    if (auth !== undefined) this.auth = auth
+    else {
+      this.auth = {
+        key: EnvironmentUtility.Get('COINBASE_API_KEY'),
+        secret: EnvironmentUtility.Get('COINBASE_API_SECRET'),
+        passphrase: EnvironmentUtility.Get('COINBASE_API_PASSPHRASE'),
+      }
+    }
 
     this.urls = {
       api: `https://${sandbox ? 'api-public.sandbox' : 'api'}.${this.root_url}`,

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,12 +3,14 @@
   "version": "0.2.1",
   "exports": "./mod.ts",
   "tasks": {
-    "coverage": "deno test --coverage=coverage",
+    "test": "deno test --allow-read --allow-env",
+    "coverage": "deno test --allow-read --allow-env --coverage=coverage",
     "coverage:lcov": "deno coverage --lcov --output=coverage/lcov.info",
     "coverage:html": "deno coverage coverage --html"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^0.226.0",
+    "@std/dotenv": "jsr:@std/dotenv@^0.224.2",
     "@std/encoding": "jsr:@std/encoding@^0.224.3"
   },
   "fmt": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "packages": {
     "specifiers": {
       "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
+      "jsr:@std/dotenv@^0.224.2": "jsr:@std/dotenv@0.224.2",
       "jsr:@std/encoding@^0.224.3": "jsr:@std/encoding@0.224.3",
       "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0"
     },
@@ -12,6 +13,9 @@
         "dependencies": [
           "jsr:@std/internal@^1.0.0"
         ]
+      },
+      "@std/dotenv@0.224.2": {
+        "integrity": "29081695357e4534696c9e986b2560be29c141ccf52daa32b6c20ff5b5c64ab9"
       },
       "@std/encoding@0.224.3": {
         "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
@@ -25,6 +29,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^0.226.0",
+      "jsr:@std/dotenv@^0.224.2",
       "jsr:@std/encoding@^0.224.3"
     ]
   }

--- a/utilities/environment.utility.test.ts
+++ b/utilities/environment.utility.test.ts
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { EnvironmentUtility } from './environment.utility.ts'
+import { assertEquals } from '@std/assert'
+
+Deno.test('EnvironmentUtility.IsDeno', async (test) => {
+  await test.step('returns true when running in Deno', () => {
+    assertEquals(EnvironmentUtility.IsDeno(), true)
+  })
+})
+
+Deno.test('EnvironmentUtility.IsBun', async (test) => {
+  await test.step('returns false when running in Deno', () => {
+    assertEquals(EnvironmentUtility.IsBun(), false)
+  })
+})
+
+Deno.test('EnvironmentUtility.Get', async (test) => {
+  await test.step('returns a key if it exists', () => {
+    Deno.env.set('FOO', 'bar')
+    assertEquals(EnvironmentUtility.Get('FOO'), 'bar')
+  })
+
+  await test.step('returns a default value if the key does not exist', () => {
+    assertEquals(EnvironmentUtility.Get('Bar'), '')
+    assertEquals(EnvironmentUtility.Get('Bar', 'foo'), 'foo')
+  })
+})

--- a/utilities/environment.utility.ts
+++ b/utilities/environment.utility.ts
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import '@std/dotenv/load'
+
+/**
+ * Unfortunatly, Deno and Bun have different ways of handling environment variables
+ * and this isn't easy to test. This utility class helps to abstract the differences
+ * a little bit.
+ * @todo Find a way to test this in real environments?
+ */
+export class EnvironmentUtility {
+  public static IsDeno(): boolean {
+    // @ts-ignore - Deno won't be defined in Bun
+    return typeof Deno !== 'undefined'
+  }
+
+  public static IsBun(): boolean {
+    // @ts-ignore - Bun won't be defined in Deno
+    return typeof Bun !== 'undefined'
+  }
+
+  public static Get(key: string, default_value: string = ''): string {
+    if (EnvironmentUtility.IsDeno()) {
+      // @ts-ignore - Deno won't be defined in Bun
+      return Deno.env.get(key) || default_value
+    } else if (this.IsBun()) {
+      // @ts-ignore - Bun won't be defined in Deno
+      return Bun.env[key] || default_value
+    } else {
+      console.error(
+        'EnvironmentUtility.Get: Not in a supported environment (deno/bun), returning default value',
+      )
+      return default_value
+    }
+  }
+}


### PR DESCRIPTION
Allos setting auth config in environment (also through .env files) and using specific keys automatically.