### PR TITLE
docs(readme): better progress tracking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,44 +15,128 @@ vanilla JavaScript bundle or definition files**.
 The public API may change before v1. Breaking changes will effect minor versions. Pinning to a patch
 version is fine for non-breaking changes.
 
-## Progress
+## REST Progress ([Documentation](https://docs.cdp.coinbase.com/exchange/reference/))
 
-REST [Documentation](https://docs.cdp.coinbase.com/exchange/reference/)
+| Module                                                                                                                                   | Status |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | -----: |
+| **Auth** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/rest-auth/))                                                           |     ✅ |
+| **Errors** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/rest-requests/))                                                     |        |
+| **Accounts**                                                                                                                             |        |
+| --- [Get all accounts for a profile](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaccounts/)                      |        |
+| --- [Get a single account by id](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaccount/)                           |        |
+| --- [Get a single account's holds](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaccountholds/)                    |        |
+| --- [Get a single account's ledger](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaccountledger/)                  |        |
+| --- [Get a single account's transfers](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaccounttransfers/)            |        |
+| **Address Book**                                                                                                                         |        |
+| --- [Get address book](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getaddressbook/)                                 |        |
+| --- [Add addresses](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postaddressbook/)                                   |        |
+| --- [Delete address](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_deleteaddressbookentry/)                           |        |
+| **Coinbase Accounts**                                                                                                                    |        |
+| --- [Get all Coinbase wallets](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getcoinbaseaccounts/)                    |        |
+| --- [Generate crypto address](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postcoinbaseaccountaddresses/)            |        |
+| **Conversions**                                                                                                                          |        |
+| --- [Convert currency](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postconversion/)                                 |        |
+| --- [Get conversion fee rates](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getconversionfees/)                      |        |
+| --- [Get a conversion](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getconversion/)                                  |        |
+| **Currencies**                                                                                                                           |     ✅ |
+| --- [Get all known currencies](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getcurrencies/)                          |     ✅ |
+| --- [Get a currency](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getcurrency/)                                      |     ✅ |
+| **Transfers**                                                                                                                            |        |
+| --- [Deposit from Coinbase account](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postdepositcoinbaseaccount/)        |        |
+| --- [Deposit from payment method](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postdepositpaymentmethod/)            |        |
+| --- [Get all payment methods](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getpaymentmethods/)                       |        |
+| --- [Get all transfers](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_gettransfers/)                                  |        |
+| --- [Get a single transfer](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_gettransfer/)                               |        |
+| --- [Submit travel information for a transfer](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_posttransfertravelrule/) |        |
+| --- [Withdraw to Coinbase account](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postwithdrawcoinbaseaccount/)        |        |
+| --- [Withdraw to crypto address](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postwithdrawcrypto/)                   |        |
+| --- [Get fee estimate for crypto withdrawal](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getwithdrawfeeestimate/)   |        |
+| --- [Withdraw to payment method](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postwithdrawpaymentmethod/)            |        |
+| **Fees**                                                                                                                                 |        |
+| --- [Get fees](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getfees/)                                                |        |
+| **Orders**                                                                                                                               |        |
+| --- [Get all fills](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getfills/)                                          |        |
+| --- [Get all orders](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getorders/)                                        |        |
+| --- [Cancel all orders](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_deleteorders/)                                  |        |
+| --- [Create a new order](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postorders/)                                   |        |
+| --- [Get single order](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getorder/)                                       |        |
+| --- [Cancel an order](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_deleteorder/)                                     |        |
+| **Loans**                                                                                                                                |        |
+| --- [List loans](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getloans/)                                             |        |
+| --- [List loan assets](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getloanassets/)                                  |        |
+| --- [Get all interest summaries](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getinterestsummary/)                   |        |
+| --- [Get a single loan's interest rate history](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getinteresthistory/)    |        |
+| --- [Get a single loan's interest charges](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getinterestcharges/)         |        |
+| --- [Get lending overview](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getloanlendingoverview/)                     |        |
+| --- [Get new loan preview](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getloanpreview/)                             |        |
+| --- [Open new loan](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_openloan/)                                          |        |
+| --- [List new loan options](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getnewloanoptions/)                         |        |
+| --- [Repay loan interest](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_repayinterest/)                               |        |
+| --- [Repay loan principal](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_repayprincipal/)                             |        |
+| --- [Get principal repayment preview](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getrepaymentpreview/)             |        |
+| **Coinbase Price Oracle**                                                                                                                |        |
+| --- [Get signed prices](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getcoinbasepriceoracle/)                        |        |
+| **Products**                                                                                                                             |        |
+| --- [Get all known trading pairs](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproducts/)                         |        |
+| --- [Get all product volume](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductsvolume/)                        |        |
+| --- [Get single product](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproduct/)                                   |        |
+| --- [Get product book](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductbook/)                                 |        |
+| --- [Get product candles](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductcandles/)                           |        |
+| --- [Get product stats](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductstats/)                               |        |
+| --- [Get product ticker](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductticker/)                             |        |
+| --- [Get product trades](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproducttrades/)                             |        |
+| **Profiles**                                                                                                                             |     ✅ |
+| --- [Get profiles](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getprofiles/)                                        |     ✅ |
+| --- [Create a profile](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postprofile/)                                    |     ✅ |
+| --- [Transfer funds between profiles](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postprofiletransfer/)             |     ✅ |
+| --- [Get profile by id](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getprofile/)                                    |     ✅ |
+| --- [Rename a profile](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_putprofile/)                                     |     ✅ |
+| --- [Delete a profile](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_putprofiledeactivate/)                           |     ✅ |
+| **Reports**                                                                                                                              |        |
+| --- [Get all reports](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getreports/)                                      |        |
+| --- [Create a report](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postreports/)                                     |        |
+| --- [Get a report](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getreport/)                                          |        |
+| **Travel Rules**                                                                                                                         |        |
+| --- [Get all travel rule information](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_gettravelrules/)                  |        |
+| --- [Create travel rule entry](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_posttravelrule/)                         |        |
+| --- [Delete existing travel rule entry](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_deletetravelrule/)              |        |
+| **Users**                                                                                                                                |        |
+| --- [Get user exchange limits](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getuserexchangelimits/)                  |        |
+| --- [Update settlement preference](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postuserlevelsettlementpreferences/) |        |
+| --- [Get user trading volumes](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getusertradingvolumes/)                  |        |
+| **Wrapped Assets**                                                                                                                       |        |
+| --- [Get all wrapped assets](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getwrappedassets/)                         |        |
+| --- [Get all stake-wraps](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getallwrappedassetstakewraps/)                |        |
+| --- [Create a new stake-wrap](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postwrappedassetstakewrap/)               |        |
+| --- [Get a single stake-wrap](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getwrappedassetstakewrap/)                |        |
+| --- [Get wrapped asset details](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getwrappedasset/)                       |        |
+| --- [Get wrapped asset conversion rate](https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getwrappedassetconversionrate/) |        |
 
-- [x] Auth
-- [ ] Accounts
-- [ ] Address Book
-- [ ] Coinbase Accounts
-- [ ] Conversions
-- [x] Currencies
-- [ ] Transfers
-- [ ] Fees
-- [ ] Orders
-- [ ] Loans
-- [ ] Coinbase Price Oracle
-- [ ] Products
-- [x] Profiles
-- [ ] Reports
-- [ ] Travel Rules
-- [ ] Users
-- [ ] Wrapped Assets
+## WebSocket Channel Progress ([Documentation](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/))
 
-WebSocket Channels [Documentation](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/)
-
-- [x] Auth
-- [ ] Heartbeat
-- [ ] Status
-- [ ] Auction
-- [ ] Matches
-- [ ] RFQ Matches
-- [ ] Ticker
-- [ ] Ticket Batch
-- [ ] Full
-- [ ] User
-- [ ] Level2
-- [ ] Level2 Batch
-- [ ] Level 3
-- [ ] Balance
+| Module                                                                                                               | Status |
+| -------------------------------------------------------------------------------------------------------------------- | -----: |
+| **Auth** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-auth/))                                  |        |
+| **Errors** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-errors/))                              |        |
+| **Heartbeat** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#heartbeat-channel))       |        |
+| **Status** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#status-channel))             |        |
+| **Auction** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#auction-channel))           |        |
+| **Matches** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#matches-channel))           |        |
+| **RFQ Matches** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#rfq-matches-channel))   |        |
+| **Ticker** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#ticker-channel))             |        |
+| **Ticker Batch** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#ticker-batch-channel)) |        |
+| **Full** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#full-channel))                 |        |
+| --- [Received](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#received)                             |        |
+| --- [Open](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#open)                                     |        |
+| --- [Done](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#done)                                     |        |
+| --- [Match](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#match)                                   |        |
+| --- [Change](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#change)                                 |        |
+| --- [Activate](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#activate)                             |        |
+| **User** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#user-channel))                 |        |
+| **Level2** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#level2-channel))             |        |
+| **Level2 Batch** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#level2-batch-channel)) |        |
+| **Level3** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#level3-channel))             |        |
+| **Balance** ([Reference](https://docs.cdp.coinbase.com/exchange/docs/websocket-channels/#balance-channel))           |        |
 
 ## License
 


### PR DESCRIPTION
There were two problems with the previous method of tracking progress: 1, it didn't play well with the JSR package page and 2, it didn't encourage (or show) partial module progress. This fixes both of those, albeit a little long windedly.