### PR TITLE
feat(resources/orders): add endpoints for single orders

### DIFF
--- a/coinbase.test.ts
+++ b/coinbase.test.ts
@@ -9,6 +9,7 @@ import { get_config } from './core/config/config.ts'
 import { assertEquals, assertInstanceOf } from '@std/assert'
 import { CoinbaseAccounts } from './resources/accounts/accounts.resource.ts'
 import { CoinbaseCurrencies } from './resources/currencies/currencies.resource.ts'
+import { CoinbaseOrders } from './resources/orders/orders.resource.ts'
 import { CoinbaseProfiles } from './resources/profiles/profiles.resource.ts'
 
 /**
@@ -19,6 +20,7 @@ Deno.test('Coinbase', () => {
   const coinbase = new Coinbase()
   assertInstanceOf(coinbase.accounts, CoinbaseAccounts)
   assertInstanceOf(coinbase.currencies, CoinbaseCurrencies)
+  assertInstanceOf(coinbase.orders, CoinbaseOrders)
   assertInstanceOf(coinbase.profiles, CoinbaseProfiles)
 })
 

--- a/coinbase.ts
+++ b/coinbase.ts
@@ -7,18 +7,21 @@
 import { type CoinbaseConfig, type CoinbaseOptions, get_config } from './core/config/config.ts'
 import { CoinbaseAccounts } from './resources/accounts/accounts.resource.ts'
 import { CoinbaseCurrencies } from './resources/currencies/currencies.resource.ts'
+import { CoinbaseOrders } from './resources/orders/orders.resource.ts'
 import { CoinbaseProfiles } from './resources/profiles/profiles.resource.ts'
 
 export class Coinbase {
   public readonly config: CoinbaseConfig
   public readonly accounts: CoinbaseAccounts
   public readonly currencies: CoinbaseCurrencies
+  public readonly orders: CoinbaseOrders
   public readonly profiles: CoinbaseProfiles
 
   constructor(options?: CoinbaseOptions) {
     this.config = get_config(options)
     this.accounts = new CoinbaseAccounts(this.config)
     this.currencies = new CoinbaseCurrencies(this.config)
+    this.orders = new CoinbaseOrders(this.config)
     this.profiles = new CoinbaseProfiles(this.config)
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -15,5 +15,9 @@ export * from './resources/accounts/accounts.types.ts'
 export type { CoinbaseCurrencies } from './resources/currencies/currencies.resource.ts'
 export * from './resources/currencies/currencies.types.ts'
 
+export type { CoinbaseOrders } from './resources/orders/orders.resource.ts'
+export * from './resources/orders/orders.types.ts'
+export * from './resources/orders/orders.dtos.ts'
+
 export type { CoinbaseProfiles } from './resources/profiles/profiles.resource.ts'
 export * from './resources/profiles/profiles.types.ts'

--- a/resources/orders/orders.dtos.ts
+++ b/resources/orders/orders.dtos.ts
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type {
+  CoinbaseOrderCancelAfter,
+  CoinbaseOrderSelfTradePrevention,
+  CoinbaseOrderSide,
+  CoinbaseOrderStopType,
+  CoinbaseOrderTimeInForce,
+  CoinbaseOrderType,
+} from './orders.types.ts'
+
+interface CoinbaseOrderDTO extends Record<string, unknown> {
+  product_id: string
+  profile_id?: string
+  client_oid?: string
+  type: CoinbaseOrderType
+  side: CoinbaseOrderSide
+  stp?: CoinbaseOrderSelfTradePrevention
+}
+
+export interface CoinbaseMarketOrderDTO extends CoinbaseOrderDTO {
+  size?: string
+  funds?: string
+}
+
+export interface CoinbaseLimitOrderDTO extends CoinbaseOrderDTO {
+  price: string
+  size: string
+  time_in_force?: CoinbaseOrderTimeInForce
+  cancel_after?: CoinbaseOrderCancelAfter
+  post_only?: boolean
+  max_floor?: string
+}
+
+export interface CoinbaseStopOrderDTO extends CoinbaseLimitOrderDTO {
+  stop: CoinbaseOrderStopType
+  stop_price: string
+  stop_limit_price: string
+}

--- a/resources/orders/orders.resource.ts
+++ b/resources/orders/orders.resource.ts
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { type CoinbaseOrder, CoinbaseOrderType } from './orders.types.ts'
+import type { CoinbaseConfig } from '../../core/config/config.ts'
+import { CoinbaseResource } from '../resource.ts'
+import type {
+  CoinbaseLimitOrderDTO,
+  CoinbaseMarketOrderDTO,
+  CoinbaseStopOrderDTO,
+} from './orders.dtos.ts'
+
+export class CoinbaseOrders extends CoinbaseResource {
+  constructor(config: CoinbaseConfig) {
+    super(config, '/orders', true)
+  }
+
+  /** @todo: This endpoint needs pagination, which is not currently supported. */
+  // public async all(): Promise<CoinbaseOrder[]> {}
+
+  /**
+   * Get a single order by id. Requires Authentication.
+   * This endpoint requires either the "view" or "trade" permission.
+   * See: https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getorder/
+   * @param id either the exchange assigned id or the client assigned client_oid. When using client_oid it must be preceded by the client: namespace.
+   * @param market_type Market type which the order was traded in.
+   */
+  public async get(id: string, market_type?: string): Promise<CoinbaseOrder> {
+    const query = market_type !== undefined ? [{ key: 'market_type', value: market_type }] : []
+    return await this.request.get<CoinbaseOrder>(`/${id}`, query)
+  }
+
+  /**
+   * Create an order. Requires Authentication.
+   * You can place two types of orders: limit and market. Orders can only be placed if your account
+   * has sufficient funds. Once an order is placed, your account funds will be put on hold for the
+   * duration of the order. How much and which funds are put on hold depends on the order type and
+   * parameters specified.
+   * This endpoint requires the "trade" permission.
+   * See: https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_postorders/
+   * @todo Add sub resources to make interacting with the order engine's rules easier.
+   */
+  public async create(
+    dto: CoinbaseStopOrderDTO,
+    type: CoinbaseOrderType.STOP,
+  ): Promise<CoinbaseOrder>
+  public async create(
+    dto: CoinbaseLimitOrderDTO,
+    type: CoinbaseOrderType.LIMIT,
+  ): Promise<CoinbaseOrder>
+  public async create(
+    dto: CoinbaseMarketOrderDTO,
+    type: CoinbaseOrderType = CoinbaseOrderType.MARKET,
+  ): Promise<CoinbaseOrder> {
+    return await this.request.post<CoinbaseOrder>(undefined, { ...dto, type })
+  }
+
+  /**
+   * Cancel an order. Requires Authentication.
+   * Cancel a single open order by id.
+   * The order must belong to the profile that the API key belongs to. If the order had no matches during its lifetime, its record may be purged. This means the order details is not available with GET /orders/<id>.
+   * To prevent a race condition when canceling an order, it is highly recommended that you specify the product id as a query string.
+   * See: https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_deleteorder/
+   * @param id either the exchange assigned id or the client assigned client_oid. When using client_oid it must be preceded by the client: namespace.
+   */
+  public async cancel(id: string, product_id?: string): Promise<void> {
+    const query = product_id !== undefined ? [{ key: 'product_id', value: product_id }] : []
+    return await this.request.delete(`/${id}`, query)
+  }
+}

--- a/resources/orders/orders.types.ts
+++ b/resources/orders/orders.types.ts
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export interface CoinbaseOrder {
+  id: string
+  product_id: string
+  side: CoinbaseOrderSide
+  type: CoinbaseOrderType
+  post_only: boolean
+  created_at: string
+  fill_fees: string
+  filled_size: string
+  status: CoinbaseOrderStatus
+  settled: boolean
+  price?: string
+  size?: string
+  profile_id?: string
+  funds?: string
+  specified_funds?: string
+  time_in_force?: CoinbaseOrderTimeInForce
+  expire_time?: string
+  done_at?: string
+  done_reason?: string
+  reject_reason?: string
+  executed_value?: string
+  stop?: CoinbaseOrderStopType
+  stop_price?: string
+  funding_amount?: string
+  client_oid?: string
+  market_type?: string
+  max_floor?: string
+  secondary_order_id?: string
+  stop_limit_price?: string
+}
+
+export enum CoinbaseOrderSide {
+  BUY = 'buy',
+  SELL = 'sell',
+}
+
+export enum CoinbaseOrderType {
+  LIMIT = 'limit',
+  MARKET = 'market',
+  STOP = 'stop',
+}
+
+export enum CoinbaseOrderStopType {
+  LOSS = 'loss',
+  ENTRY = 'entry',
+}
+
+export enum CoinbaseOrderTimeInForce {
+  GOOD_TILL_CANCELED = 'GTC',
+  GOOD_TILL_DATE = 'GTD',
+  IMMEDIATE_OR_CANCEL = 'IOC',
+  FILL_OR_KILL = 'FOK',
+}
+
+export enum CoinbaseOrderStatus {
+  OPEN = 'open',
+  PENDING = 'pending',
+  REJECTED = 'rejected',
+  DONE = 'done',
+  ACTIVE = 'active',
+  RECEIVED = 'received',
+  ALL = 'all',
+}
+
+export enum CoinbaseOrderSelfTradePrevention {
+  DECREMENT_AND_CANCEL = 'dc',
+  CANCEL_OLDEST = 'co',
+  CANCEL_NEWEST = 'cn',
+  CANCEL_BOTH = 'cb',
+}
+
+export enum CoinbaseOrderCancelAfter {
+  MIN = 'min',
+  HOUR = 'hour',
+  DAY = 'day',
+}


### PR DESCRIPTION
Interacting with multiple orders requires pagination, which is on the list but I wan ted to at least get this out for now. I'm also considering an improved api with sub resources for orders specifically due to the rules around posting orders. More to come for sure.