### PR TITLE
fix(core): pass the correct url (only path) to auth

### DIFF
--- a/core/rest/request/request.module.ts
+++ b/core/rest/request/request.module.ts
@@ -12,7 +12,7 @@ import { RequestUtility } from './request.utility.ts'
 export class CoinbaseRequest {
   /** Make a request to the Coinbase API. */
   static async Send<T>(method: RequestMethod, data: RequestData, auth?: CoinbaseAuthConfig) {
-    const url = `${data.path}${RequestUtility.ParseQuery(data.query)}`
+    const url = `${data.url}${data.path}${RequestUtility.ParseQuery(data.query)}`
     const headers = await RequestUtility.GetHeaders(method, data, auth)
     const body = data.body ? JSON.stringify(data.body) : undefined
     const response = await fetch(url, { headers, method, body })

--- a/core/rest/request/request.types.ts
+++ b/core/rest/request/request.types.ts
@@ -15,6 +15,7 @@ export enum RequestMethod {
 }
 
 export interface RequestData {
+  url: string
   path: string
   query?: Query
   // deno-lint-ignore no-explicit-any

--- a/core/rest/request/request.utility.test.ts
+++ b/core/rest/request/request.utility.test.ts
@@ -11,6 +11,8 @@ import { TEST_AUTH_CONFIG, TEST_AUTH_KEYS } from '../../testing/core.test.data.t
 import { auth } from '../../auth/auth.ts'
 import { RequestMethod } from './request.types.ts'
 
+const url = 'https://example.coinbase.com'
+
 Deno.test('RequestUtility.ParseQuery()', () => {
   assertEquals(RequestUtility.ParseQuery(), '')
   assertEquals(RequestUtility.ParseQuery([]), '')
@@ -23,7 +25,7 @@ Deno.test('RequestUtility.ParseQuery()', () => {
 
 Deno.test('RequestUtility.GetHeaders()', async (test) => {
   await test.step('returns base headers with no auth', async () => {
-    const headers = await RequestUtility.GetHeaders(RequestMethod.GET, { path: '/test' })
+    const headers = await RequestUtility.GetHeaders(RequestMethod.GET, { url, path: '/test' })
     assertEquals(headers, RequestUtility.BASE_HEADERS)
   })
 
@@ -32,7 +34,7 @@ Deno.test('RequestUtility.GetHeaders()', async (test) => {
     const auth_headers = auth.get_headers(TEST_AUTH_KEYS)
     const headers = await RequestUtility.GetHeaders(
       RequestMethod.GET,
-      { path: '/test' },
+      { url, path: '/test' },
       TEST_AUTH_CONFIG,
     )
     assertEquals(headers, { ...RequestUtility.BASE_HEADERS, ...auth_headers })

--- a/core/rest/rest.test.ts
+++ b/core/rest/rest.test.ts
@@ -11,22 +11,25 @@ import { CoinbaseRequest } from './request/request.module.ts'
 import { CoinbaseRest } from './rest.ts'
 
 const test_url = 'https://test.coinbase.com'
+const test_path = '/test'
 
 Deno.test('CoinbaseRest.constructor()', async (test) => {
   await test.step('sets url', () => {
-    const rest = new CoinbaseRest(test_url)
-    assertEquals(rest.url, test_url)
+    const rest = new CoinbaseRest(test_url, test_path)
+    assertEquals(rest.root, test_url)
+    assertEquals(rest.base, test_path)
     assertEquals(rest.auth, undefined)
   })
 
   await test.step('sets auth', () => {
-    const rest = new CoinbaseRest(test_url, TEST_AUTH_CONFIG)
-    assertEquals(rest.url, test_url)
+    const rest = new CoinbaseRest(test_url, test_path, TEST_AUTH_CONFIG)
+    assertEquals(rest.root, test_url)
+    assertEquals(rest.base, test_path)
     assertEquals(rest.auth, TEST_AUTH_CONFIG)
   })
 })
 
-const rest = new CoinbaseRest(test_url)
+const rest = new CoinbaseRest(test_url, test_path)
 async function test_method(
   method: 'get' | 'post' | 'put' | 'delete',
   stub_method: 'Get' | 'Post' | 'Put' | 'Delete',
@@ -35,7 +38,10 @@ async function test_method(
   const request_stub = stub(CoinbaseRequest, stub_method, () => Promise.resolve({}))
   await rest[method](`/${method.toLowerCase()}-request`)
   assertSpyCall(request_stub, 0, {
-    args: [{ path: test_url + `/${method.toLowerCase()}-request`, ...other_params }, undefined],
+    args: [
+      { url: test_url, path: test_path + `/${method.toLowerCase()}-request`, ...other_params },
+      undefined,
+    ],
   })
   request_stub.restore()
 }

--- a/core/rest/rest.ts
+++ b/core/rest/rest.ts
@@ -12,39 +12,45 @@ export * from './request/request.types.ts'
 
 /** Subclass for resource apis to be cleaner. Cleaner access to CoinbaseRequest */
 export class CoinbaseRest {
-  public readonly url: string
+  public readonly root: string
+  public readonly base: string
   public readonly auth: CoinbaseAuthConfig | undefined
 
   /**
    * @param base_url Base url for the rest instance, will be prepended to all requests.
    * @param auth Optional auth configuration for the rest instance, will be passed to all requests.
    */
-  constructor(base_url: string, auth?: CoinbaseAuthConfig) {
-    this.url = base_url
+  constructor(root: string, base: string, auth?: CoinbaseAuthConfig) {
+    this.root = root
+    this.base = base
     this.auth = auth
+  }
+
+  public url_data(path: string): RequestData {
+    return { url: this.root, path: this.base + path }
   }
 
   /** Make a GET request to the Coinbase API. */
   public async get<T>(path = '', query?: Query): Promise<T> {
-    const data: RequestData = { path: this.url + path, query }
+    const data: RequestData = { url: this.root, path: this.base + path, query }
     return await CoinbaseRequest.Get<T>(data, this.auth)
   }
 
   /** Make a POST request to the Coinbase API. */
   public async post<T>(path = '', body?: Record<string, unknown>): Promise<T> {
-    const data: RequestData = { path: this.url + path, body }
+    const data: RequestData = { ...this.url_data(path), body }
     return await CoinbaseRequest.Post<T>(data, this.auth)
   }
 
   /** Make a PUT request to the Coinbase API. */
   public async put<T>(path = '', body?: Record<string, unknown>): Promise<T> {
-    const data: RequestData = { path: this.url + path, body }
+    const data: RequestData = { ...this.url_data(path), body }
     return await CoinbaseRequest.Put<T>(data, this.auth)
   }
 
   /** Make a DELETE request to the Coinbase API. */
   public async delete<T>(path = '', query?: Query): Promise<T> {
-    const data: RequestData = { path: this.url + path, query }
+    const data: RequestData = { ...this.url_data(path), query }
     return await CoinbaseRequest.Delete<T>(data, this.auth)
   }
 }

--- a/resources/resource.ts
+++ b/resources/resource.ts
@@ -12,12 +12,11 @@ export abstract class CoinbaseResource {
 
   /**
    * @param config Pass along the configuration object from the parent instance.
-   * @param path Subpath to an api endpoint that all requests from this instance will make.
+   * @param base_path Subpath to an api endpoint that all requests from this instance will make.
    * @param has_auth Whether or not this request instance requires authentication.
    */
-  constructor(config: CoinbaseConfig, path: string, has_auth: boolean = false) {
-    const base_url = config.urls.api + path
+  constructor(config: CoinbaseConfig, base_path: string, has_auth: boolean = false) {
     const auth = has_auth ? config.auth : undefined
-    this.request = new CoinbaseRest(base_url, auth)
+    this.request = new CoinbaseRest(config.urls.api, base_path, auth)
   }
 }


### PR DESCRIPTION
During the refactor for auth/requests the url being passed into auth methods went from just the path to the full URL of the request. This fixes that. x.x